### PR TITLE
fix: Remove check for seeked every position update

### DIFF
--- a/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
+++ b/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
@@ -60,6 +60,15 @@ open class MuxStateCollector(
 
   /**
    * The current state of the player, as represented by Mux Data. Only mutable from the inside
+   *
+   * @see pause
+   * @see playing
+   * @see buffering
+   * @see seeking
+   * @see seeked
+   * @see playingAds
+   * @see finishedPlayingAds
+   * @see ended
    */
   @Suppress("MemberVisibilityCanBePrivate")
   val muxPlayerState by ::_playerState
@@ -301,7 +310,6 @@ open class MuxStateCollector(
   fun seeked() {
     // Only handle if we were previously seeking
     if (seekingInProgress) {
-      dispatch(SeekedEvent(null))
       seekingInProgress = false
       _playerState = MuxPlayerState.SEEKED
     }

--- a/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
+++ b/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
@@ -52,16 +52,14 @@ open class MuxStateCollector(
 
   /**
    * This is the time to wait in ms that needs to pass after the player has seeked in
-   * order for us to conclude that playback has actually started. We use this value in a workaround
-   * to detect the playing event when {@link SeekedEvent} event is some times reported by
-   * {@link ExoPlayer} a few milliseconds after the {@link PlayingEvent} which is not what is
-   * expected.
+   * order for us to conclude that playback has actually started. This is to ensure that callback
+   * ordering doesn't cause state issues during sometimes-chaotic player startup
    * */
   @Suppress("unused")
   var timeToWaitAfterFirstFrameReceived: Long = 50
 
   /**
-   * The current state of the player, as represented by Mux Data
+   * The current state of the player, as represented by Mux Data. Only mutable from the inside
    */
   @Suppress("MemberVisibilityCanBePrivate")
   val muxPlayerState by ::_playerState
@@ -136,9 +134,10 @@ open class MuxStateCollector(
    * For HLS live streams, the PROGRAM-DATE-TIME or an approximation
    */
   @Suppress("MemberVisibilityCanBePrivate")
-  val hlsPlayerProgramTime: Long? get() {
-    return hlsManifestNewestTime?.let { it + playbackPositionMills }
-  }
+  val hlsPlayerProgramTime: Long?
+    get() {
+      return hlsManifestNewestTime?.let { it + playbackPositionMills }
+    }
 
   /**
    * For HLS streams, the newest timestamp received (for live, this ~= the time we started watching)
@@ -218,6 +217,7 @@ open class MuxStateCollector(
     ) {
       if (_playerState == MuxPlayerState.PLAYING) {
         // If we were playing then the player buffers, that's re-buffering instead
+        //  Buffering can also happen because of seeking
         rebufferingStarted()
       } else {
         _playerState = MuxPlayerState.BUFFERING
@@ -298,12 +298,13 @@ open class MuxStateCollector(
    * Call when the player has stopped seeking. This is normally handled automatically, but may need
    * to be called if there was an surprise position discontinuity in some cases
    *
-   * This method can also infer a PLAYING state transition, if required. Use @param inferPlayingState
+   * @param checkIfMissedSeeked If true, this method will check for missed seek-ends and dispatched
+   *      'seeked' and 'playing' only if appropriate
    */
-  fun seeked(inferPlayingState: Boolean) {
+  fun seeked(checkIfMissedSeeked: Boolean) {
     // Only handle if we were previously seeking
     if (seekingInProgress) {
-      if (inferPlayingState) {
+      if (checkIfMissedSeeked) {
         // If inferring playing state, we may also assume the player is playing based on
         // collected state data
         if (
@@ -343,7 +344,7 @@ open class MuxStateCollector(
     // TODO: We are getting a seeking() before the start of the view for some reason.
     //  This (I think?) causes state handling for another event to call seeked()
     //  We should eliminate the improper seeking() call, or find good criteria to ignore it,
-    //  or reset seeking state (possibly other state data too) when ViewStart is dispatched (use an IEventListener I guess)
+
     if (playEventsSent == 0) {
       // Ignore this, we have received a seek event before we have received playerready event,
       // so this event should be ignored.
@@ -593,6 +594,7 @@ open class MuxStateCollector(
           stateCollector.playbackPositionMills = position
           // pick up seeked events that may not otherwise be delivered in sequence
           if (stateCollector.seekingInProgress) {
+            // seeked() can infer the playing state and decide whether there was actually a seek
             stateCollector.seeked(true)
           }
         } else {

--- a/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
+++ b/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
@@ -312,6 +312,7 @@ open class MuxStateCollector(
   fun seeked() {
     // Only handle if we were previously seeking
     if (seekingInProgress) {
+      dispatch(SeekedEvent(null))
       seekingInProgress = false
       _playerState = MuxPlayerState.SEEKED
     }

--- a/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
+++ b/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
@@ -59,7 +59,9 @@ open class MuxStateCollector(
   var timeToWaitAfterFirstFrameReceived: Long = 50
 
   /**
-   * The current state of the player, as represented by Mux Data. Only mutable from the inside
+   * The current state of the player, as represented by Mux Data. This value changes in response to
+   * player state events reported by you. The events are reported via methods like [pause], [play],
+   * [seeking], etc
    *
    * @see pause
    * @see playing

--- a/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
+++ b/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
@@ -287,7 +287,7 @@ open class MuxStateCollector(
       rebufferingEnded()
     }
     if (seekingInProgress) {
-      seeked(false)
+      seeked()
       return
     }
     _playerState = MuxPlayerState.PAUSED
@@ -297,40 +297,17 @@ open class MuxStateCollector(
   /**
    * Call when the player has stopped seeking. This is normally handled automatically, but may need
    * to be called if there was an surprise position discontinuity in some cases
-   *
-   * @param checkIfMissedSeeked If true, this method will check for missed seek-ends and dispatched
-   *      'seeked' and 'playing' only if appropriate
    */
-  fun seeked(checkIfMissedSeeked: Boolean) {
+  fun seeked() {
     // Only handle if we were previously seeking
     if (seekingInProgress) {
-      if (checkIfMissedSeeked) {
-        // If inferring playing state, we may also assume the player is playing based on
-        // collected state data
-        if (
-          (((System.currentTimeMillis() - firstFrameRenderedAtMillis
-                  > timeToWaitAfterFirstFrameReceived) && firstFrameReceived) || !mediaHasVideoTrack!!)
-          && seekingEventsSent > 0
-        ) {
-          // This is a playback !!!
-          dispatch(SeekedEvent(null))
-          seekingInProgress = false
-          MuxLogger.d("MuxStats", "Playing called from seeked event !!!")
-          playing()
-        } else {
-          // No playback yet.
-          MuxLogger.d("MuxStats", "Seeked before playback started")
-        }
-      } else {
-        // If not inferring player state, just dispatch the event
-        dispatch(SeekedEvent(null))
-        seekingInProgress = false
-        _playerState = MuxPlayerState.SEEKED
-      }
+      dispatch(SeekedEvent(null))
+      seekingInProgress = false
+      _playerState = MuxPlayerState.SEEKED
+    }
 
-      if (seekingEventsSent == 0) {
-        seekingInProgress = false
-      }
+    if (seekingEventsSent == 0) {
+      seekingInProgress = false
     }
   }
 

--- a/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
+++ b/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
@@ -592,11 +592,6 @@ open class MuxStateCollector(
         val position = getTimeMillis()
         if (position != null) {
           stateCollector.playbackPositionMills = position
-          // pick up seeked events that may not otherwise be delivered in sequence
-          if (stateCollector.seekingInProgress) {
-            // seeked() can infer the playing state and decide whether there was actually a seek
-            stateCollector.seeked(true)
-          }
         } else {
           // If the data source is returning null, assume caller cleaned up the player
           MuxLogger.d(logTag(), "PlaybackPositionWatcher: Player lost. Stopping")

--- a/mux-kt-utils/src/main/java/com/mux/android/util/Weak.kt
+++ b/mux-kt-utils/src/main/java/com/mux/android/util/Weak.kt
@@ -19,9 +19,9 @@ fun <T> weak(t: T?): ReadWriteProperty<Any, T?> = Weak(t)
 fun <T> weak(): ReadWriteProperty<Any, T?> = Weak(null)
 
 /**
- * Property Delegate where the property's referent is not reachable
+ * Property Delegate where the property's referent is weakly-reachable via the property
  * The implementation is private, but within this module you can use weak(...) to use this class
- *   (this prevents Weak from being instantiated in java with `new Weak$library()`)
+ *   (this prevents Weak from being instantiated in java with `new Weak()`)
  */
 private class Weak<T>(referent: T?) : ReadWriteProperty<Any, T?> {
   private var weakT = WeakReference(referent)


### PR DESCRIPTION
This is the callers responsibility, and no caller even needs it. The check was a workaround for an old exoplayer version, and if we need something like it, the caller can do it with the block the pass to they `PlayerWatcher`