### PR TITLE
misc: Move the common test tools into their own package

### DIFF
--- a/core-android/src/test/java/com/mux/core_android/AndroidDeviceTests.kt
+++ b/core-android/src/test/java/com/mux/core_android/AndroidDeviceTests.kt
@@ -6,10 +6,11 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import com.mux.android.util.allEqual
-import com.mux.core_android.testdoubles.mockActivity
-import com.mux.core_android.testdoubles.mockConnectivityManager16
-import com.mux.core_android.testdoubles.mockConnectivityManager23
-import com.mux.core_android.testdoubles.mockSharedPrefs
+import com.mux.core_android.test.tools.AbsRobolectricTest
+import com.mux.core_android.test.tools.testdoubles.mockActivity
+import com.mux.core_android.test.tools.testdoubles.mockConnectivityManager16
+import com.mux.core_android.test.tools.testdoubles.mockConnectivityManager23
+import com.mux.core_android.test.tools.testdoubles.mockSharedPrefs
 import com.mux.stats.sdk.muxstats.MuxDataSdk
 import org.junit.Assert.*
 import org.junit.Test

--- a/core-android/src/test/java/com/mux/core_android/PlayerAdapterTests.kt
+++ b/core-android/src/test/java/com/mux/core_android/PlayerAdapterTests.kt
@@ -1,8 +1,9 @@
 package com.mux.core_android
 
 import android.view.View
-import com.mux.core_android.testdoubles.FakePlayerBinding
-import com.mux.core_android.testdoubles.mockView
+import com.mux.core_android.test.tools.AbsRobolectricTest
+import com.mux.core_android.test.tools.testdoubles.FakePlayerBinding
+import com.mux.core_android.test.tools.testdoubles.mockView
 import com.mux.stats.sdk.muxstats.MuxPlayerAdapter
 import com.mux.stats.sdk.muxstats.MuxStateCollector
 import com.mux.stats.sdk.muxstats.MuxUiDelegate

--- a/core-android/src/test/java/com/mux/core_android/StateCollectorTests.kt
+++ b/core-android/src/test/java/com/mux/core_android/StateCollectorTests.kt
@@ -1,6 +1,7 @@
 package com.mux.core_android
 
-import com.mux.core_android.testdoubles.FakeEventDispatcher
+import com.mux.core_android.test.tools.AbsRobolectricTest
+import com.mux.core_android.test.tools.testdoubles.FakeEventDispatcher
 import com.mux.stats.sdk.core.events.EventBus
 import com.mux.stats.sdk.core.events.IEvent
 import com.mux.stats.sdk.core.events.playback.*

--- a/core-android/src/test/java/com/mux/core_android/UiDelegateTests.kt
+++ b/core-android/src/test/java/com/mux/core_android/UiDelegateTests.kt
@@ -2,12 +2,13 @@ package com.mux.core_android
 
 import android.app.Activity
 import android.view.View
-import com.mux.core_android.testdoubles.MOCK_PLAYER_HEIGHT
-import com.mux.core_android.testdoubles.MOCK_PLAYER_WIDTH
-import com.mux.core_android.testdoubles.MOCK_SCREEN_HEIGHT
-import com.mux.core_android.testdoubles.MOCK_SCREEN_WIDTH
-import com.mux.core_android.testdoubles.mockActivity
-import com.mux.core_android.testdoubles.mockView
+import com.mux.core_android.test.tools.AbsRobolectricTest
+import com.mux.core_android.test.tools.testdoubles.MOCK_PLAYER_HEIGHT
+import com.mux.core_android.test.tools.testdoubles.MOCK_PLAYER_WIDTH
+import com.mux.core_android.test.tools.testdoubles.MOCK_SCREEN_HEIGHT
+import com.mux.core_android.test.tools.testdoubles.MOCK_SCREEN_WIDTH
+import com.mux.core_android.test.tools.testdoubles.mockActivity
+import com.mux.core_android.test.tools.testdoubles.mockView
 import com.mux.stats.sdk.muxstats.muxUiDelegate
 import com.mux.stats.sdk.muxstats.noUiDelegate
 import io.mockk.every

--- a/core-android/src/test/java/com/mux/core_android/test/tools/AbsRobolectricTest.kt
+++ b/core-android/src/test/java/com/mux/core_android/test/tools/AbsRobolectricTest.kt
@@ -1,6 +1,6 @@
-package com.mux.core_android
+package com.mux.core_android.test.tools
 
-import com.mux.core_android.testdoubles.FakeMuxDevice
+import com.mux.core_android.test.tools.testdoubles.FakeMuxDevice
 import com.mux.stats.sdk.muxstats.MuxStats
 import org.junit.Before
 import org.junit.runner.RunWith

--- a/core-android/src/test/java/com/mux/core_android/test/tools/Log.kt
+++ b/core-android/src/test/java/com/mux/core_android/test/tools/Log.kt
@@ -1,6 +1,4 @@
-package com.mux.core_android
-
-import java.lang.Exception
+package com.mux.core_android.test.tools
 
 fun log(tag: String = "\t", message: String, ex: Throwable? = null) {
   println("$tag :: $message")

--- a/core-android/src/test/java/com/mux/core_android/test/tools/testdoubles/FakeEventDispatcher.kt
+++ b/core-android/src/test/java/com/mux/core_android/test/tools/testdoubles/FakeEventDispatcher.kt
@@ -1,4 +1,4 @@
-package com.mux.core_android.testdoubles
+package com.mux.core_android.test.tools.testdoubles
 
 import com.mux.stats.sdk.core.events.IEvent
 import com.mux.stats.sdk.core.events.IEventDispatcher

--- a/core-android/src/test/java/com/mux/core_android/test/tools/testdoubles/FakeMuxDevice.kt
+++ b/core-android/src/test/java/com/mux/core_android/test/tools/testdoubles/FakeMuxDevice.kt
@@ -1,6 +1,6 @@
-package com.mux.core_android.testdoubles
+package com.mux.core_android.test.tools.testdoubles
 
-import com.mux.core_android.log
+import com.mux.core_android.test.tools.log
 import com.mux.stats.sdk.muxstats.IDevice
 import com.mux.stats.sdk.muxstats.LogPriority
 

--- a/core-android/src/test/java/com/mux/core_android/test/tools/testdoubles/FakeNetwork.kt
+++ b/core-android/src/test/java/com/mux/core_android/test/tools/testdoubles/FakeNetwork.kt
@@ -1,7 +1,7 @@
-package com.mux.core_android.testdoubles
+package com.mux.core_android.test.tools.testdoubles
 
 import android.net.Uri
-import com.mux.core_android.log
+import com.mux.core_android.test.tools.log
 import com.mux.stats.sdk.muxstats.INetworkRequest
 import com.mux.android.http.beaconAuthority
 import com.mux.android.util.logTag

--- a/core-android/src/test/java/com/mux/core_android/test/tools/testdoubles/FakePlayerBinding.kt
+++ b/core-android/src/test/java/com/mux/core_android/test/tools/testdoubles/FakePlayerBinding.kt
@@ -1,7 +1,7 @@
-package com.mux.core_android.testdoubles
+package com.mux.core_android.test.tools.testdoubles
 
 import com.mux.android.util.logTag
-import com.mux.core_android.log
+import com.mux.core_android.test.tools.log
 import com.mux.stats.sdk.muxstats.MuxPlayerAdapter
 import com.mux.stats.sdk.muxstats.MuxStateCollector
 

--- a/core-android/src/test/java/com/mux/core_android/test/tools/testdoubles/Mocks.kt
+++ b/core-android/src/test/java/com/mux/core_android/test/tools/testdoubles/Mocks.kt
@@ -1,4 +1,4 @@
-package com.mux.core_android.testdoubles
+package com.mux.core_android.test.tools.testdoubles
 
 import android.app.Activity
 import android.content.Context


### PR DESCRIPTION
This is to facilitate copying them into other tests

In the future it would be cool to publish these tools as a library for data SDK test variants