### PR TITLE
fix: should handle 'playing' from 'INIT' state, by sending 'play'

### DIFF
--- a/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
+++ b/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
@@ -262,13 +262,18 @@ open class MuxStateCollector(
    */
   @Suppress("unused")
   fun playing() {
-    // Negative Logic Version
     if (seekingInProgress) {
       // We will dispatch playing event after seeked event
       MuxLogger.d("MuxStats", "Ignoring playing event, seeking in progress !!!")
       return
     }
-    if (_playerState.oneOf(MuxPlayerState.PAUSED, MuxPlayerState.FINISHED_PLAYING_ADS)) {
+    if (
+      _playerState.oneOf(
+        MuxPlayerState.PAUSED,
+        MuxPlayerState.FINISHED_PLAYING_ADS,
+        MuxPlayerState.INIT,
+      )
+    ) {
       play()
     } else if (_playerState == MuxPlayerState.REBUFFERING) {
       rebufferingEnded()


### PR DESCRIPTION
This helps catch cases where the player is prepared before we are attached, and also provides resilience against concurrency issues leading to out-of-order events