### PR TITLE
fix: events sent synchronously during setup are missed

### DIFF
--- a/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxDataSdk.kt
+++ b/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxDataSdk.kt
@@ -283,12 +283,11 @@ abstract class MuxDataSdk<Player, PlayerView : View> @JvmOverloads protected con
       customOptions
     )
     collector = makeStateCollector(muxStats, eventBus, trackFirstFrame)
+    eventBus.addListener(muxStats)
+    muxStats.customerData = customerData
     playerAdapter = makePlayerAdapter(
       player, uiDelegate, collector, playerBinding
     )
-
-    muxStats.customerData = customerData
-    eventBus.addListener(muxStats)
 
     muxStats.allowLogcatOutput(
       logLevel.oneOf(LogcatLevel.DEBUG, LogcatLevel.VERBOSE),


### PR DESCRIPTION
Sometimes player SDKs may need to send out Data or Playback events to represent the state of the player at the time the data SDKs were attached. Without this fix, those events would be ignored because we have to set up the `eventBus` before any events can be tracked.