### PR TITLE
Releases/v1.0.0

### DIFF
--- a/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxDataSdk.kt
+++ b/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxDataSdk.kt
@@ -283,12 +283,11 @@ abstract class MuxDataSdk<Player, PlayerView : View> @JvmOverloads protected con
       customOptions
     )
     collector = makeStateCollector(muxStats, eventBus, trackFirstFrame)
+    eventBus.addListener(muxStats)
+    muxStats.customerData = customerData
     playerAdapter = makePlayerAdapter(
       player, uiDelegate, collector, playerBinding
     )
-
-    muxStats.customerData = customerData
-    eventBus.addListener(muxStats)
 
     muxStats.allowLogcatOutput(
       logLevel.oneOf(LogcatLevel.DEBUG, LogcatLevel.VERBOSE),

--- a/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
+++ b/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
@@ -262,13 +262,18 @@ open class MuxStateCollector(
    */
   @Suppress("unused")
   fun playing() {
-    // Negative Logic Version
     if (seekingInProgress) {
       // We will dispatch playing event after seeked event
       MuxLogger.d("MuxStats", "Ignoring playing event, seeking in progress !!!")
       return
     }
-    if (_playerState.oneOf(MuxPlayerState.PAUSED, MuxPlayerState.FINISHED_PLAYING_ADS)) {
+    if (
+      _playerState.oneOf(
+        MuxPlayerState.PAUSED,
+        MuxPlayerState.FINISHED_PLAYING_ADS,
+        MuxPlayerState.INIT,
+      )
+    ) {
       play()
     } else if (_playerState == MuxPlayerState.REBUFFERING) {
       rebufferingEnded()


### PR DESCRIPTION
## Improvements
* When handling 'playing' from 'INIT' state, send 'play' (#47)

## Fixes
* fix: events sent synchronously during setup are missed (#48)



Co-authored-by: Emily Dixon <edixon@mux.com>
Co-authored-by: GitHub <noreply@github.com>