### PR TITLE
Additional resolution fixes for ViewModel/Service use case

### DIFF
--- a/core-android/build.gradle
+++ b/core-android/build.gradle
@@ -54,7 +54,7 @@ muxDistribution {
 dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 
-  api "com.mux:stats.muxcore:8.0.1"
+  api "com.mux:stats.muxcore:dev-absurd_resolution_upscale-2c54ec1"
 
   debugImplementation project(':mux-kt-utils')
   afterEvaluate { // The version isn't computed until after this file is finalized thanks to agp 8

--- a/core-android/build.gradle
+++ b/core-android/build.gradle
@@ -54,7 +54,7 @@ muxDistribution {
 dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 
-  api "com.mux:stats.muxcore:dev-absurd_resolution_upscale-2c54ec1"
+  api "com.mux:stats.muxcore:8.0.1"
 
   debugImplementation project(':mux-kt-utils')
   afterEvaluate { // The version isn't computed until after this file is finalized thanks to agp 8

--- a/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxUiDelegate.kt
+++ b/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxUiDelegate.kt
@@ -48,6 +48,7 @@ private class AndroidUiDelegate<PlayerView : View>(context: Context?, view: Play
   MuxUiDelegate<PlayerView>(view) {
 
   private var _screenSize: Point = screenSizeFromContext(context)
+
   private var displayDensity = displayDensityFromContext(context)
 
   override var view: PlayerView?
@@ -55,9 +56,9 @@ private class AndroidUiDelegate<PlayerView : View>(context: Context?, view: Play
       return super.view
     }
     set(value) {
-//      val ctx = value?.context
-//      _screenSize = screenSizeFromContext(ctx)
-//      displayDensity = displayDensityFromContext(ctx)
+      val ctx = value?.context
+      _screenSize = screenSizeFromContext(ctx)
+      displayDensity = displayDensityFromContext(ctx)
       super.view = value
     }
 

--- a/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxUiDelegate.kt
+++ b/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxUiDelegate.kt
@@ -48,7 +48,6 @@ private class AndroidUiDelegate<PlayerView : View>(context: Context?, view: Play
   MuxUiDelegate<PlayerView>(view) {
 
   private var _screenSize: Point = screenSizeFromContext(context)
-
   private var displayDensity = displayDensityFromContext(context)
 
   override var view: PlayerView?
@@ -56,9 +55,9 @@ private class AndroidUiDelegate<PlayerView : View>(context: Context?, view: Play
       return super.view
     }
     set(value) {
-      val ctx = value?.context
-      _screenSize = screenSizeFromContext(ctx)
-      displayDensity = displayDensityFromContext(ctx)
+//      val ctx = value?.context
+//      _screenSize = screenSizeFromContext(ctx)
+//      displayDensity = displayDensityFromContext(ctx)
       super.view = value
     }
 

--- a/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxUiDelegate.kt
+++ b/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxUiDelegate.kt
@@ -12,8 +12,9 @@ import com.mux.stats.sdk.core.util.MuxLogger
 
 /**
  * Allows implementers to supply data about the view and screen being used for playback
+ * @param PV An object that can be used to access view and screen metrics, like a [View]
  */
-abstract class MuxUiDelegate<PlayerView>(view: PlayerView?) {
+abstract class MuxUiDelegate<PV>(view: PV?) {
   open var view by weak(view)
 
   /**

--- a/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxUiDelegate.kt
+++ b/core-android/src/main/java/com/mux/stats/sdk/muxstats/MuxUiDelegate.kt
@@ -14,7 +14,7 @@ import com.mux.stats.sdk.core.util.MuxLogger
  * Allows implementers to supply data about the view and screen being used for playback
  */
 abstract class MuxUiDelegate<PlayerView>(view: PlayerView?) {
-  var view by weak(view)
+  open var view by weak(view)
 
   /**
    * Gets the size of the player view in px as a pair of (width, height)
@@ -47,9 +47,20 @@ abstract class MuxUiDelegate<PlayerView>(view: PlayerView?) {
 private class AndroidUiDelegate<PlayerView : View>(context: Context?, view: PlayerView?) :
   MuxUiDelegate<PlayerView>(view) {
 
-  private val _screenSize: Point =
-    context?.let { it as? Activity }?.let { screenSize(it) } ?: Point()
-  private val displayDensity = context?.resources?.displayMetrics?.density ?: 0F
+  private var _screenSize: Point = screenSizeFromContext(context)
+
+  private var displayDensity = displayDensityFromContext(context)
+
+  override var view: PlayerView?
+    get() {
+      return super.view
+    }
+    set(value) {
+      val ctx = value?.context
+      _screenSize = screenSizeFromContext(ctx)
+      displayDensity = displayDensityFromContext(ctx)
+      super.view = value
+    }
 
   override fun getPlayerViewSize(): Point = view?.let { view ->
     Point().apply {
@@ -59,6 +70,14 @@ private class AndroidUiDelegate<PlayerView : View>(context: Context?, view: Play
   } ?: Point()
 
   override fun getScreenSize(): Point = _screenSize
+
+  private fun displayDensityFromContext(context: Context?): Float {
+    return context?.resources?.displayMetrics?.density ?: 0F
+  }
+
+  private fun screenSizeFromContext(context: Context?): Point {
+    return context?.let { it as? Activity }?.let { screenSize(it) } ?: Point()
+  }
 
   private fun screenSize(activity: Activity): Point {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -110,7 +129,7 @@ private class AndroidUiDelegate<PlayerView : View>(context: Context?, view: Play
 @Suppress("unused")
 @JvmSynthetic
 internal fun <V : View> V.muxUiDelegate(context: Context)
-        : MuxUiDelegate<V> = AndroidUiDelegate(context as? Activity, this)
+    : MuxUiDelegate<V> = AndroidUiDelegate(context as? Activity, this)
 
 /**
  * Create a MuxUiDelegate for a view-less playback experience. Returns 0 for all sizes, as we are
@@ -118,4 +137,5 @@ internal fun <V : View> V.muxUiDelegate(context: Context)
  */
 @Suppress("unused")
 @JvmSynthetic
-internal fun <V : View> noUiDelegate(context: Context): MuxUiDelegate<V> = AndroidUiDelegate(context, null)
+internal fun <V : View> noUiDelegate(context: Context): MuxUiDelegate<V> =
+  AndroidUiDelegate(context, null)


### PR DESCRIPTION
Unfortunately we can't unit test this because bare java fields like `DisplayMetrics.density` can't be mocked