### PR TITLE
Releases/v1.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-  id 'com.android.application' version '8.6.0' apply false
-  id 'com.android.library' version '8.6.0' apply false
+  id 'com.android.application' version '8.6.1' apply false
+  id 'com.android.library' version '8.6.1' apply false
   id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
   id 'com.mux.gradle.android.mux-android-distribution' version '1.3.0' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-  id 'com.android.application' version '8.4.2' apply false
-  id 'com.android.library' version '8.4.2' apply false
+  id 'com.android.application' version '8.6.0' apply false
+  id 'com.android.library' version '8.6.0' apply false
   id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
-  id 'com.mux.gradle.android.mux-android-distribution' version '1.2.1' apply false
+  id 'com.mux.gradle.android.mux-android-distribution' version '1.3.0' apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Aug 01 16:07:05 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -77,7 +77,7 @@ muxDistribution {
 dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 
-  api "com.mux:stats.muxcore:8.1.0"
+  api "com.mux:stats.muxcore:8.1.1"
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'androidx.test.ext:junit:1.1.5'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,14 +5,14 @@ plugins {
 }
 
 android {
-  compileSdk 34
+  compileSdk 35
 
   namespace "com.mux.core_android"
 
   defaultConfig {
     minSdk 16
     //noinspection EditedTargetSdkVersion
-    targetSdk 34
+    targetSdk 35
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
@@ -75,12 +75,12 @@ muxDistribution {
 }
 
 dependencies {
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
 
   api "com.mux:stats.muxcore:8.1.1"
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test.ext:junit:1.1.5'
+  testImplementation 'androidx.test.ext:junit:1.2.1'
   testImplementation "io.mockk:mockk:1.13.9"
   // hm, seems like they got rid of API 16 at some point, so we'd have to handle that.
   //   Robolectric doesn't need updated for anything in particular tho, test deps aren't exported

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
 </manifest>

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/MuxDataSdk.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/MuxDataSdk.kt
@@ -316,6 +316,9 @@ abstract class MuxDataSdk<Player, PlayerView : View> @JvmOverloads protected con
       logLevel.oneOf(LogcatLevel.DEBUG, LogcatLevel.VERBOSE),
       logLevel == LogcatLevel.VERBOSE
     )
+    if (logLevel == LogcatLevel.VERBOSE) {
+      MuxLogger.enable("all", muxStats)
+    }
   }
 
   /**

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/MuxDataSdk.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/MuxDataSdk.kt
@@ -596,8 +596,8 @@ abstract class MuxDataSdk<Player, PlayerView : View> @JvmOverloads protected con
         } else {
           getPackageInfoLegacy(ctx)
         }
-        appName = packageInfo.packageName
-        appVersion = packageInfo.versionName
+        appName = packageInfo.packageName ?: ""
+        appVersion = packageInfo.versionName ?: ""
       } catch (e: PackageManager.NameNotFoundException) {
         MuxLogger.d(TAG, "could not get package info")
       }


### PR DESCRIPTION
## Improvements
* Verbose logging turns on error logging also
* fix: verbose logging causing beacons to fail
* fix: rebuffering time inflated if user seeks during rebuffering
* Update java core to v8.1.1.

Co-authored-by: Emily Dixon <edixon@mux.com>