### PR TITLE
Releases/v1.4.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ This SDK is meant to be a base for other Mux Data SDKs for Android
 
 ## Usage
 
-Add the dependency to your SDK.
+Add this library and the Java Core to your SDK
 
 ```groovy
+// this library
 api 'com.mux.stats.sdk.muxstats:android:1.2.0'
+// You *must* specify an exact version of MuxCore in your player integration
+api 'com.mux:stats.muxcore:8.4.2'
 ```
 
 Implement `PlayerBinding<>` to listen for changes from your Player

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this library and the Java Core to your SDK
 // this library
 api 'com.mux.stats.sdk.muxstats:android:1.2.0'
 // You *must* specify an exact version of MuxCore in your player integration
-api 'com.mux:stats.muxcore:8.4.2'
+api 'com.mux:stats.muxcore:8.4.1'
 ```
 
 Implement `PlayerBinding<>` to listen for changes from your Player

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,9 @@ android {
 dependencies {
 
   project(":library")
+  // dynamic version so the player SDKs on top of this can update core independently
+  //noinspection GradleDynamicVersion
+  implementation("com.mux:stats.muxcore:8.+")
 
   implementation("androidx.core:core-ktx:1.15.0")
   implementation("androidx.appcompat:appcompat:1.7.0")

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -79,6 +79,8 @@ dependencies {
   // dynamic version/compileOnly so the player SDKs on top of this can update core independently
   //noinspection GradleDynamicVersion
   compileOnly "com.mux:stats.muxcore:8.+"
+  //noinspection GradleDynamicVersion
+  testImplementation "com.mux:stats.muxcore:8.+"
 
   testImplementation 'androidx.test.ext:junit-ktx:1.2.1'
   testImplementation 'junit:junit:4.13.2'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -76,7 +76,9 @@ muxDistribution {
 dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
 
-  api "com.mux:stats.muxcore:8.4.0"
+  // dynamic version/compileOnly so the player SDKs on top of this can update core independently
+  //noinspection GradleDynamicVersion
+  compileOnly "com.mux:stats.muxcore:8.+"
 
   testImplementation 'androidx.test.ext:junit-ktx:1.2.1'
   testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
## Fixes
* fix: Incorrect minified keys for `viewer_client_application_name` and `viewer_client_application_version`

## Improvements

* Make MuxCore updateable independently (but player SDKs must explicitly declare their Core version)



Co-authored-by: Emily Dixon <edixon@mux.com>