### PR TITLE
fix: AbstractMethodError with some integrations

### DIFF
--- a/library/src/main/java/com/mux/stats/sdk/muxstats/MuxDataSdk.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/MuxDataSdk.kt
@@ -246,10 +246,8 @@ abstract class MuxDataSdk<Player, PlayerView : View> @JvmOverloads protected con
     @Suppress("MemberVisibilityCanBePrivate")
     protected fun pxToDp(px: Int): Int = convertPxToDp(px, uiDelegate.displayDensity())
 
-    override fun getSourceCodec(): String? {
-      // Mux's SDKs use this only during renditionchange
-      return null
-    }
+    // Mux's SDKs set this dimension only during renditionchange so our impl here can return null
+    override fun getSourceCodec(): String? = null
     override fun getCurrentPosition(): Long = collector?.playbackPositionMills ?: 0L
     override fun getMimeType() = collector?.mimeType
     override fun getSourceWidth(): Int? = collector?.sourceWidth

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/MuxDataSdk.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/MuxDataSdk.kt
@@ -246,6 +246,10 @@ abstract class MuxDataSdk<Player, PlayerView : View> @JvmOverloads protected con
     @Suppress("MemberVisibilityCanBePrivate")
     protected fun pxToDp(px: Int): Int = convertPxToDp(px, uiDelegate.displayDensity())
 
+    override fun getSourceCodec(): String? {
+      // Mux's SDKs use this only during renditionchange
+      return null
+    }
     override fun getCurrentPosition(): Long = collector?.playbackPositionMills ?: 0L
     override fun getMimeType() = collector?.mimeType
     override fun getSourceWidth(): Int? = collector?.sourceWidth


### PR DESCRIPTION
`getSourceCodec()` has a `default` implementation in Java, but the Kotlin subclass isn't always able to delegate to the default method in `IPlayerListener`. This will cause `AbstractMethodError`s at runtime because an implementation of this method cannot be found.

Whether or not this happens depends on the customer kotlin version.

The default implementation returns `null`, so this is not changing any functionality. Some custom integrations must use this to set the source codec, but our own SDKs only do so during `renditionchange` so there's no chance this will regress anything