### PR TITLE
docs: correct oneOf KDoc wording

### DIFF
--- a/library/src/main/java/com/mux/android/util/Util.kt
+++ b/library/src/main/java/com/mux/android/util/Util.kt
@@ -3,14 +3,14 @@ package com.mux.android.util
 import kotlin.math.ceil
 
 /**
- * Returns true if the receiver is not in the given objects.
+ * Returns true if the receiver is in the given objects.
  *
  * For example `"blue".oneOf("red", "green") == false` and `3.oneOf(3,5,6) == true`
  */
 fun <Any> Any.oneOf(vararg these: Any) = these.contains(this)
 
 /**
- * Returns true if the receiver is not in the given objects.
+ * Returns true if the receiver is in the given objects.
  *
  * For example `"blue".oneOf("red", "green") == false` and `3.oneOf(3,5,6) == true`
  */


### PR DESCRIPTION
## Summary
- correct KDoc text for `oneOf(vararg ...)` to describe actual behavior
- correct KDoc text for `oneOf(Collection<...>)` to describe actual behavior
- no code behavior changes; docs-only update

## Why
`oneOf` uses `contains`, so it returns `true` when the receiver *is in* the provided values. The previous KDoc incorrectly said *not in*.

## Test plan
- [x] docs-only change
- [x] examples remain accurate (`\"blue\".oneOf(\"red\", \"green\") == false`, `3.oneOf(3,5,6) == true`)